### PR TITLE
Add Docker aliases and Claude Code skills for git workflow

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -59,6 +59,8 @@ alias ag='rg'
 alias git-rm-branches='git branch | grep -v "^\*" | xargs git branch -d'
 alias chrome="open -a /Applications/Google\ Chrome.app"
 alias p="pnpm"
+alias d="docker"
+alias dc="docker compose"
 
 # ##### ##### ##### ##### #####
 # ssh-agent

--- a/claude/skills/commit-and-push/SKILL.md
+++ b/claude/skills/commit-and-push/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: commit-and-push
+description: 変更をステージングしてコミットし、リモートにプッシュする
+user-invocable: true
+allowed-tools: Bash(git status*), Bash(git diff*), Bash(git log*), Bash(git add *), Bash(git commit *), Bash(git push*), Bash(git rev-parse*)
+---
+
+変更内容を確認し、コミットしてリモートにプッシュする。
+
+## 手順
+
+### 1. 現在の状態を把握（並行実行）
+
+以下の3つを **並行して** 実行する:
+
+1. `git status` で変更ファイル一覧を取得
+2. `git diff` と `git diff --staged` で差分を確認
+3. `git log --oneline -10` で直近のコミットメッセージのスタイルを確認
+
+### 2. 変更がない場合
+
+変更がなければその旨を報告して終了。
+
+### 3. コミットメッセージの作成
+
+- 変更内容を分析し、簡潔なコミットメッセージを作成する
+- リポジトリの既存コミットメッセージのスタイルに合わせる
+- 「何を変えたか」ではなく「なぜ変えたか」にフォーカスする
+- `.env` やクレデンシャル系ファイルが含まれていたら警告して除外する
+
+### 4. ステージングとコミット
+
+1. 関連ファイルを `git add` でステージング（`git add -A` は使わず、ファイル名を明示する）
+2. コミットメッセージは HEREDOC 形式で渡す:
+   ```bash
+   git commit -m "$(cat <<'EOF'
+   コミットメッセージ
+
+   Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+   EOF
+   )"
+   ```
+3. `git status` で結果を確認
+
+### 5. プッシュ
+
+1. `git rev-parse --abbrev-ref HEAD` で現在のブランチ名を取得
+2. `git push origin <ブランチ名>` でリモートにプッシュ
+   - リモートブランチが存在しない場合は `git push -u origin <ブランチ名>` を使う
+
+### 6. 結果報告
+
+コミットとプッシュの結果を簡潔に報告する。

--- a/claude/skills/commit/SKILL.md
+++ b/claude/skills/commit/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: commit
+description: 変更をステージングしてコミットする
+user-invocable: true
+allowed-tools: Bash(git status*), Bash(git diff*), Bash(git log*), Bash(git add *), Bash(git commit *)
+---
+
+変更内容を確認し、適切なコミットメッセージでコミットする。
+
+## 手順
+
+### 1. 現在の状態を把握（並行実行）
+
+以下の3つを **並行して** 実行する:
+
+1. `git status` で変更ファイル一覧を取得
+2. `git diff` と `git diff --staged` で差分を確認
+3. `git log --oneline -10` で直近のコミットメッセージのスタイルを確認
+
+### 2. 変更がない場合
+
+変更がなければその旨を報告して終了。
+
+### 3. コミットメッセージの作成
+
+- 変更内容を分析し、簡潔なコミットメッセージを作成する
+- リポジトリの既存コミットメッセージのスタイルに合わせる
+- 「何を変えたか」ではなく「なぜ変えたか」にフォーカスする
+- `.env` やクレデンシャル系ファイルが含まれていたら警告して除外する
+
+### 4. ステージングとコミット
+
+1. 関連ファイルを `git add` でステージング（`git add -A` は使わず、ファイル名を明示する）
+2. コミットメッセージは HEREDOC 形式で渡す:
+   ```bash
+   git commit -m "$(cat <<'EOF'
+   コミットメッセージ
+
+   Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+   EOF
+   )"
+   ```
+3. `git status` で結果を確認
+
+### 5. 結果報告
+
+コミット結果を簡潔に報告する。

--- a/claude/skills/create-pr/SKILL.md
+++ b/claude/skills/create-pr/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: create-pr
+description: 現在のブランチからプルリクエストを作成する
+user-invocable: true
+allowed-tools: Bash(git status*), Bash(git diff*), Bash(git log*), Bash(git push*), Bash(git rev-parse*), Bash(git symbolic-ref*), Bash(git checkout -b *), Bash(gh pr create*)
+---
+
+現在のブランチの変更内容を分析し、PRを作成する。
+
+## 手順
+
+### 1. 現在の状態を把握（並行実行）
+
+以下を **並行して** 実行する:
+
+1. `git status` で未コミットの変更がないか確認
+2. `git rev-parse --abbrev-ref HEAD` で現在のブランチ名を取得
+3. `git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'` でデフォルトブランチ名を取得
+
+### 2. 未コミットの変更がある場合
+
+未コミットの変更があれば警告し、先にコミットするよう促して終了。
+
+### 3. デフォルトブランチ上にいる場合
+
+デフォルトブランチ上にいる場合は、適切なブランチ名を提案して `git checkout -b <ブランチ名>` で新しいブランチを作成する。
+
+### 4. 変更内容の分析
+
+1. `git log <デフォルトブランチ>..HEAD --oneline` で含まれるコミット一覧を取得
+2. `git diff <デフォルトブランチ>...HEAD` で差分全体を確認
+3. 変更の目的と影響範囲を把握する
+
+### 5. リモートにプッシュ
+
+1. `git push -u origin <ブランチ名>` でリモートにプッシュ
+
+### 6. PR作成
+
+PRタイトルとサマリを作成し、`gh pr create` で作成する:
+
+- タイトルは70文字以内で簡潔に
+- 本文は HEREDOC 形式で渡す:
+  ```bash
+  gh pr create --title "タイトル" --body "$(cat <<'EOF'
+  ## Summary
+  - 変更点を箇条書きで
+
+  ## Test plan
+  - [ ] テスト項目
+
+  🤖 Generated with [Claude Code](https://claude.com/claude-code)
+  EOF
+  )"
+  ```
+
+### 7. 結果報告
+
+作成したPRのURLを報告する。


### PR DESCRIPTION
## Summary
- `d` (docker), `dc` (docker compose) のエイリアスを `.zshrc` に追加
- Claude Code スキルを3つ追加:
  - `/commit` — 変更をステージング&コミット
  - `/commit-and-push` — コミット&プッシュ
  - `/create-pr` — PRの作成

## Test plan
- [ ] `source ~/.zshrc` 後に `d --version`, `dc version` が動作する
- [ ] `/commit`, `/commit-and-push`, `/create-pr` が Claude Code で認識される

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * Docker コマンドの短縮エイリアス（`d`、`dc`）を追加
  * Git 操作の自動化スキルを新規追加：変更のステージングとコミット、リモートへのプッシュ、プルリクエスト作成に対応

<!-- end of auto-generated comment: release notes by coderabbit.ai -->