### PR TITLE
refactor(skills): simplify ai-image-gen into a generic image generator

### DIFF
--- a/claude/skills/ai-image-gen/SKILL.md
+++ b/claude/skills/ai-image-gen/SKILL.md
@@ -12,20 +12,17 @@ vercel-labs/ai-cli を使ってローカルから画像を生成する。`AI Gat
 
 ## 起動条件 / 前提
 
-- `op`（1Password CLI）がインストール済みでアプリ統合が有効（`/opt/homebrew/bin/op`）
-- ai-cli が公式手順（`npm i -g ai-cli`）で導入済み。**未導入なら下記「未導入時のインストール」に従って入れてからリトライ**
-- Vercel AI Gateway に**有料クレジット**がある（無料枠は画像モデルを弾く。2026-06-09 に $20 投入済み）
+すべて満たしてから本処理に進む。
 
-### 未導入時のインストール（node バージョン文脈ごとに必要）
+- **`op`（1Password CLI）がインストール済みで使えること**（`/opt/homebrew/bin/op`・アプリ統合が有効）。`op whoami` は "not signed in" を返すが**これは仕様で正常**（アプリ統合認証。vault/item 操作は通る）。
+- **ai-cli がインストール済みであること**（公式手順 `npm i -g ai-cli`、node >=20）。ai-cli は **node のバージョンごとの global** に入るため、別バージョンの node に切り替わるディレクトリでは `command not found` になる。その場合は**バージョン番号を固定して回避せず、その node 文脈で素直に入れて**再実行する:
 
-ai-cli は **node のバージョンごとの global** に入る（npm/nodenv の仕様）。そのため、別バージョンの node に切り替わるディレクトリで叩くと `command not found` になることがある。**事前に `ai` の有無を確認し、無ければ公式手順で今の文脈にインストールしてから本処理に進む**：
+  ```bash
+  # 確認 → 無ければ公式手順で導入
+  command -v ai >/dev/null 2>&1 || npm i -g ai-cli
+  ```
 
-```bash
-# 確認 → 無ければ公式手順で導入（ai-cli は node >=20 で動作）
-command -v ai >/dev/null 2>&1 || npm i -g ai-cli
-```
-
-`nodenv: ai: command not found` が出ても**バージョン番号を固定して回避しようとしない**。それは「今の node 文脈に未導入」のサインなので、上記コマンドで素直に入れる。
+- **Vercel AI Gateway に有料クレジットがあること**（2026-06-09 に $20 投入済み）。無料枠は画像モデルを弾く。`Free tier users do not have access to this model` はモデルID誤りではなく**クレジット不足**のサインで、top-up が必要。漏洩時の請求対策として AI Gateway 側でスペンド上限を設定しておくと安全。
 
 ## 🔑 秘匿情報の在り処（最重要・毎回ここを忘れる）
 
@@ -33,11 +30,10 @@ command -v ai >/dev/null 2>&1 || npm i -g ai-cli
   - vault=`Private` / item=`AI Gateway`（カテゴリ API_CREDENTIAL）/ field=`credential`（CONCEALED, 60文字）
 - ai-cli は **環境変数 `AI_GATEWAY_API_KEY` だけ**を読む（ログインコマンド・設定ファイルは無い）
 - `op run` が実行時だけキーを注入し、終われば消える。**平文ディスク保存ゼロ・コミット事故ゼロ**
-- `op whoami` は "not signed in" を返すが**これは仕様で正常**（アプリ統合認証。vault/item 操作は通る）
 
 ## ⚙️ 正しい叩き方
 
-`AI_GATEWAY_API_KEY` に 1Password 参照を渡し、`op run` でラップして `ai` を叩く（キーは実行時だけ注入される）。`ai` が見つからない場合は前述「未導入時のインストール」で導入してから再実行する：
+`AI_GATEWAY_API_KEY` に 1Password 参照を渡し、`op run` でラップして `ai` を叩く（キーは実行時だけ注入される）:
 
 ```bash
 AI_GATEWAY_API_KEY="op://Private/AI Gateway/credential" \
@@ -52,7 +48,7 @@ op run -- ai image "プロンプト" \
 
 ### Touch ID 連打を避ける（複数生成は1コマンドに包む）
 
-`op run` 1回につき Touch ID プロンプトが1回出る。**複数枚・複数プロンプトは `op run -- bash -c '...'` で1コマンドに束ねる**と認証1回で済む：
+`op run` 1回につき Touch ID プロンプトが1回出る。**複数枚・複数プロンプトは `op run -- bash -c '...'` で1コマンドに束ねる**と認証1回で済む:
 
 ```bash
 AI_GATEWAY_API_KEY="op://Private/AI Gateway/credential" op run -- bash -c '
@@ -64,40 +60,32 @@ ai image "PROMPT B" -m "$M" --no-preview -q -n 2 -o out/b/
 
 - プロンプト文字列にはアポストロフィ（`'`）を入れない（外側が単一引用符のため）。`cwd` は子に継承されるので相対パス（`out/...`）でOK。
 
-## 主要フラグ（`ai image --help` で確認済み）
+## 主要フラグ（`ai image --help` / ai-cli 0.2.1 で確認）
 
 | フラグ | 意味 |
 |---|---|
 | `-m, --model` | `creator/model-name`。カンマ区切りでマルチモデル比較 |
 | `-o, --output` | ファイルパス or **ディレクトリ**。dir 指定で `output-1.png` / `output-2.png` 自動命名 |
-| `-n, --count` | モデルあたり生成枚数 |
-| `--aspect-ratio` | 例 `16:9`（**flash は無視する→罠リスト参照**） |
-| `--size` | 例 `1792x1024`（ピクセル直指定） |
+| `-n, --count` | モデルあたり生成枚数（default 1） |
+| `--size` | 例 `1024x1024`（ピクセル直指定） |
+| `--aspect-ratio` | 例 `16:9`（**モデルが無視することがある→罠リスト参照**） |
 | `--quality` | `standard` / `hd` |
+| `--style` | 例 `vivid` / `natural` |
+| `-q, --quiet` | 進捗出力を抑制（Bash ツール経由では付ける） |
+| `--no-preview` | インラインプレビューを無効化（Bash ツール経由では付ける） |
 | `-p, --concurrency` | 並列生成数（default 4） |
-| `--no-preview` `-q` | ターミナル出力を抑制（Bash ツール経由では付ける） |
 | `--json` | メタデータを JSON 出力 |
 
-- **参照画像フラグ（`-i`）はこのバージョンのヘルプに無い**。過去メモの `-i ref.png` は要再検証。当面は望む世界観をテキストプロンプトに言語化する。
+- **参照画像フラグ（`-i`）は v0.2.1 のヘルプに無い**（2026-06-10 実機確認済み）。当面は望む世界観をテキストプロンプトに言語化する。
 
 ## モデル選定とコスト
 
 **`google/gemini-2.5-flash-image` をデフォルトにする。基本これで進める**（安い・速い。10枚で数十円レベル）。先回りで高いモデルを使わない。
 
-議論・目視評価の中で**「これはモデル起因の品質問題だ」と判断したときに初めて**、上位モデルへ上げる/変える:
-
-- `google/gemini-3-pro-image` — 高品質。
-- 他の候補: `google/imagen-4.0-{fast,generate,ultra}-001`, `openai/gpt-image-{1,2,1.5}`, `xai/grok-imagine-image`。
+- **デフォルトからモデルを変える前は、必ずユーザーに確認する**（コストと挙動が変わるため）。
+- 議論・目視評価の中で「これはモデル起因の品質問題だ」と判断したときに、上位モデルへ上げる/変える候補: `google/gemini-3-pro-image`（高品質）/ `google/imagen-4.0-{fast,generate,ultra}-001` / `openai/gpt-image-{1,2,1.5}` / `xai/grok-imagine-image`。
 - 全モデル一覧は `ai models` で確認（現在39個）。
-
-### 課金まわりの未対応TODO（漏洩時の請求爆弾対策）
-
-- AI Gateway ダッシュボードで ①このCLI専用キーを発行して `op` の値を差し替え ②スペンド上限設定。**未確認なら毎回ユーザーに確認**。
 
 ## 罠リスト（実証済み）
 
-- **node 文脈ごとに未導入**: ai-cli は node のバージョンごとの global に入る。別バージョンに切り替わる repo 内で `ai` が `command not found` になったら、バージョンを固定して回避するのではなく `npm i -g ai-cli`（公式手順）で今の文脈に入れて再実行する。
-- **無料枠ブロック**: `Free tier users do not have access to this model` はモデルID誤りではなく**クレジット不足**。top-up が必要。
-- **Touch ID 連打**: 1 `op run` = 1 Touch ID。複数生成は `op run -- bash -c` で束ねる。
-- **aspect-ratio が効かない（モデル依存）**: ai-cli の `--aspect-ratio` は gemini で無視される。実測（2026-06-09）: `gemini-2.5-flash-image` は **1:1（1024×1024）固定**、`gemini-3-pro-image` は **≒16:9（1408×768）固定**（指定に関わらず）。比率を厳守したいなら `--size` 直指定を試す or 別モデルで要検証。
-- **`op whoami` の "not signed in"** は正常。署名状態を疑わない。
+- **aspect-ratio が効かないことがある（モデル依存）**: `--aspect-ratio` フラグ自体は存在する（v0.2.1）が、実測（2026-06-09）では gemini 側が無視して固定サイズを返した（`gemini-2.5-flash-image`=1:1 1024×1024 / `gemini-3-pro-image`≒16:9 1408×768）。モデル・CLI バージョンで変わりうるので、**比率が重要なら使用時に `--size` 直指定で都度検証する**。

--- a/claude/skills/ai-image-gen/SKILL.md
+++ b/claude/skills/ai-image-gen/SKILL.md
@@ -15,14 +15,14 @@ vercel-labs/ai-cli を使ってローカルから画像を生成する。`AI Gat
 すべて満たしてから本処理に進む。
 
 - **`op`（1Password CLI）がインストール済みで使えること**（`/opt/homebrew/bin/op`・アプリ統合が有効）。`op whoami` は "not signed in" を返すが**これは仕様で正常**（アプリ統合認証。vault/item 操作は通る）。
-- **ai-cli がインストール済みであること**（公式手順 `npm i -g ai-cli`、node >=20）。ai-cli は **node のバージョンごとの global** に入るため、別バージョンの node に切り替わるディレクトリでは `command not found` になる。その場合は**バージョン番号を固定して回避せず、その node 文脈で素直に入れて**再実行する:
+- **ai-cli が最新で導入済みであること**（公式手順 `npm i -g ai-cli@latest`、node >=20）。**フラグや挙動はバージョンで変わる**ので最新に保つ（例: 参照画像フラグ `-i` は 0.2.x には無く 0.3.x で利用可）。ai-cli は **node のバージョンごとの global** に入るため、別バージョンの node に切り替わるディレクトリでは `command not found` になる。その場合は**バージョン番号を固定して回避せず、その node 文脈で素直に入れて**再実行する:
 
   ```bash
-  # 確認 → 無ければ公式手順で導入
-  command -v ai >/dev/null 2>&1 || npm i -g ai-cli
+  # 確認 → 無ければ／古ければ最新を導入
+  command -v ai >/dev/null 2>&1 || npm i -g ai-cli@latest
   ```
 
-- **Vercel AI Gateway に有料クレジットがあること**（2026-06-09 に $20 投入済み）。無料枠は画像モデルを弾く。`Free tier users do not have access to this model` はモデルID誤りではなく**クレジット不足**のサインで、top-up が必要。漏洩時の請求対策として AI Gateway 側でスペンド上限を設定しておくと安全。
+- **Vercel AI Gateway に有料クレジットがあること**。無料枠は画像モデルを弾く。`Free tier users do not have access to this model` はモデルID誤りではなく**クレジット不足**のサインで、top-up が必要。漏洩時の請求対策として AI Gateway 側でスペンド上限を設定しておくと安全。
 
 ## 🔑 秘匿情報の在り処（最重要・毎回ここを忘れる）
 
@@ -60,12 +60,15 @@ ai image "PROMPT B" -m "$M" --no-preview -q -n 2 -o out/b/
 
 - プロンプト文字列にはアポストロフィ（`'`）を入れない（外側が単一引用符のため）。`cwd` は子に継承されるので相対パス（`out/...`）でOK。
 
-## 主要フラグ（`ai image --help` / ai-cli 0.2.1 で確認）
+## 主要フラグ（`ai image --help` / ai-cli 0.3.1 で確認）
+
+フラグはバージョンで増減する。**実行前に `ai image --help` で都度確認する**のが確実（下表は 0.3.1 時点）。
 
 | フラグ | 意味 |
 |---|---|
 | `-m, --model` | `creator/model-name`。カンマ区切りでマルチモデル比較 |
 | `-o, --output` | ファイルパス or **ディレクトリ**。dir 指定で `output-1.png` / `output-2.png` 自動命名 |
+| `-i, --image` | 参照画像（パス or URL）。繰り返し指定可（0.3.x で利用可） |
 | `-n, --count` | モデルあたり生成枚数（default 1） |
 | `--size` | 例 `1024x1024`（ピクセル直指定） |
 | `--aspect-ratio` | 例 `16:9`（**モデルが無視することがある→罠リスト参照**） |
@@ -75,8 +78,6 @@ ai image "PROMPT B" -m "$M" --no-preview -q -n 2 -o out/b/
 | `--no-preview` | インラインプレビューを無効化（Bash ツール経由では付ける） |
 | `-p, --concurrency` | 並列生成数（default 4） |
 | `--json` | メタデータを JSON 出力 |
-
-- **参照画像フラグ（`-i`）は v0.2.1 のヘルプに無い**（2026-06-10 実機確認済み）。当面は望む世界観をテキストプロンプトに言語化する。
 
 ## モデル選定とコスト
 

--- a/claude/skills/ai-image-gen/SKILL.md
+++ b/claude/skills/ai-image-gen/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: ai-image-gen
-description: vercel-labs/ai-cli（Vercel AI Gateway 経由）でローカルから画像を生成する。秘匿キーは 1Password（op run でランタイム注入）、未導入時のインストール案内・Touch ID 連打回避・モデル選定・コスト管理の手順込み。taberu.pro / honn.me 等の X(Twitter)広告クリエイティブのビジュアル背景量産で使う。「画像生成して」「広告ビジュアル作って」「ai image」で起動。
+description: vercel-labs/ai-cli（Vercel AI Gateway 経由）でローカルから画像を生成する汎用ツール。Claude 本体が持たない「画像生成」機能を補う。秘匿キーは 1Password（op run でランタイム注入）、未導入時のインストール案内・Touch ID 連打回避・モデル選定・コスト管理の手順込み。用途は問わない（広告ビジュアル・素材・モック等）。「画像生成して」「画像作って」「ai image」で起動。
 user-invocable: true
 ---
 
 # ai-cli 画像生成（Vercel AI Gateway）
 
-vercel-labs/ai-cli を使ってローカルから画像を量産する。`AI Gateway` 経由で gemini / imagen / gpt-image 等にアクセスする。**設計思想は「ai-cli はビジュアル背景層だけ生成し、文字（コピー）は `compose-ad-creative` スキルで HTML/CSS 後乗せ」**（画像モデルは日本語が化けるため）。
+vercel-labs/ai-cli を使ってローカルから画像を生成する。`AI Gateway` 経由で gemini / imagen / gpt-image 等にアクセスする。**Claude 本体が持たない「画像生成」機能を補う汎用ツール**で、用途は問わない。
+
+> 画像モデルは**日本語テキストが化ける**ため、画像内に文字を焼きたいときは「背景だけ生成して文字は別途ベクターで後乗せ」する分業が無難（汎用 Tips）。
 
 ## 起動条件 / 前提
 
@@ -41,23 +43,26 @@ command -v ai >/dev/null 2>&1 || npm i -g ai-cli
 AI_GATEWAY_API_KEY="op://Private/AI Gateway/credential" \
 op run -- ai image "プロンプト" \
   -m google/gemini-2.5-flash-image \
-  --aspect-ratio 16:9 --no-preview -q -n 2 \
-  -o assets/ad-experiments/round1/axis/
+  --no-preview -q -n 2 \
+  -o out/
 ```
+
+- `-o` はディレクトリ指定で `output-1.png` / `output-2.png` と自動命名される。出力先は任意（コミットしたくない実験用なら `.gitignore` に逃がす）。
+- 生成画像の目視評価は Read ツールで PNG を開いて行う（捏造しない）。
 
 ### Touch ID 連打を避ける（複数生成は1コマンドに包む）
 
-`op run` 1回につき Touch ID プロンプトが1回出る。**複数枚・複数軸は `op run -- bash -c '...'` で1コマンドに束ねる**と認証1回で済む：
+`op run` 1回につき Touch ID プロンプトが1回出る。**複数枚・複数プロンプトは `op run -- bash -c '...'` で1コマンドに束ねる**と認証1回で済む：
 
 ```bash
 AI_GATEWAY_API_KEY="op://Private/AI Gateway/credential" op run -- bash -c '
 M=google/gemini-2.5-flash-image
-ai image "PROMPT A" -m "$M" --no-preview -q -n 2 -o assets/ad-experiments/round1/1-axis/
-ai image "PROMPT B" -m "$M" --no-preview -q -n 2 -o assets/ad-experiments/round1/2-axis/
+ai image "PROMPT A" -m "$M" --no-preview -q -n 2 -o out/a/
+ai image "PROMPT B" -m "$M" --no-preview -q -n 2 -o out/b/
 '
 ```
 
-- プロンプト文字列にはアポストロフィ（`'`）を入れない（外側が単一引用符のため）。`cwd` は子に継承されるので相対パス（`assets/...`）でOK
+- プロンプト文字列にはアポストロフィ（`'`）を入れない（外側が単一引用符のため）。`cwd` は子に継承されるので相対パス（`out/...`）でOK。
 
 ## 主要フラグ（`ai image --help` で確認済み）
 
@@ -73,49 +78,26 @@ ai image "PROMPT B" -m "$M" --no-preview -q -n 2 -o assets/ad-experiments/round1
 | `--no-preview` `-q` | ターミナル出力を抑制（Bash ツール経由では付ける） |
 | `--json` | メタデータを JSON 出力 |
 
-- **参照画像フラグ（`-i`）はこのバージョンのヘルプに無い**。過去メモの `-i ref.png` は要再検証。当面はブランド世界観をテキストプロンプトに言語化する
-- 生成画像の目視評価は Read ツールで PNG を開いて行う（捏造しない）
+- **参照画像フラグ（`-i`）はこのバージョンのヘルプに無い**。過去メモの `-i ref.png` は要再検証。当面は望む世界観をテキストプロンプトに言語化する。
 
 ## モデル選定とコスト
 
-`ai models` で画像モデル一覧（現在39個）。代表:
+**`google/gemini-2.5-flash-image` をデフォルトにする。基本これで進める**（安い・速い。10枚で数十円レベル）。先回りで高いモデルを使わない。
 
-- **`google/gemini-2.5-flash-image`** — 安い・速い。**幅出しラウンドはこれ**（10枚で数十円レベル）
-- **`google/gemini-3-pro-image`** — 高品質。**勝った方向の決勝生成**に使う
-- 他: `google/imagen-4.0-{fast,generate,ultra}-001`, `openai/gpt-image-{1,2,1.5}`, `xai/grok-imagine-image`
-- 戦略: **flash で量産→選別→pro で本気生成**
+議論・目視評価の中で**「これはモデル起因の品質問題だ」と判断したときに初めて**、上位モデルへ上げる/変える:
+
+- `google/gemini-3-pro-image` — 高品質。
+- 他の候補: `google/imagen-4.0-{fast,generate,ultra}-001`, `openai/gpt-image-{1,2,1.5}`, `xai/grok-imagine-image`。
+- 全モデル一覧は `ai models` で確認（現在39個）。
 
 ### 課金まわりの未対応TODO（漏洩時の請求爆弾対策）
 
-- AI Gateway ダッシュボードで ①このCLI専用キーを発行して `op` の値を差し替え ②スペンド上限設定。**未確認なら毎回ユーザーに確認**
+- AI Gateway ダッシュボードで ①このCLI専用キーを発行して `op` の値を差し替え ②スペンド上限設定。**未確認なら毎回ユーザーに確認**。
 
-## taberu.pro 広告クリエイティブ・ワークフロー（主ユースケース）
+## 罠リスト（実証済み）
 
-ゴール例: **サイト流入/お試し**。ブランド詳細・Round1 結果はメモリ `project_x_ad_creative_exploration.md` 参照。
-
-1. **コピーとビジュアルを分離**。ai-cli は文字なし背景だけ生成（テキスト用の余白 or 空の吹き出しを必ず確保）。文字は後で `compose-ad-creative` スキルで乗せる（HTML/CSS のベクター品質、$0・Figma 不要）
-2. **量で殴る**: ビジュアル軸 5方向 × 各2案＝10枚を1コマンドで生成（軸例: 写真シズル / ブランドイラスト / 応援団長マスコット / ミニマルグラデ / ポップコミック）
-3. 全枚を Read で目視評価 → ユーザーが方向を選別
-4. 勝った1〜2軸を `gemini-3-pro-image` で本気生成（Round2）
-5. `compose-ad-creative` でコピー乗せ → 既存コピー型をチャンピオンに残しつつビジュアル型を挑戦者として X で A/B
-6. 全軸に注入するブランドDNA: クリーム背景・角丸・アンバーオレンジ＋オリーブ・親しみやすい日本語アプリ調・`Absolutely no text, no letters, no words anywhere.`
-
-### 作業ディレクトリ
-
-- `assets/ad-experiments/round{N}/{軸名}/`（taberu.pro リポジトリ内。コミットしたくなければ `.gitignore` に追加）
-- ブランド設計図の既存素材: `assets/taberu-pro.png`（og-cover）
-
-## 罠リスト（このセッションで踏んだ実績）
-
-- **node 文脈ごとに未導入**: ai-cli は node のバージョンごとの global に入る。別バージョンに切り替わる repo 内で `ai` が `command not found` になったら、バージョンを固定して回避するのではなく `npm i -g ai-cli`（公式手順）で今の文脈に入れて再実行する
-- **無料枠ブロック**: `Free tier users do not have access to this model` はモデルID誤りではなく**クレジット不足**。top-up が必要
-- **Touch ID 連打**: 1 `op run` = 1 Touch ID。複数生成は `op run -- bash -c` で束ねる
-- **aspect-ratio が効かない（モデル依存）**: ai-cli の `--aspect-ratio` は gemini で無視される。実測（2026-06-09）: `gemini-2.5-flash-image` は **1:1（1024×1024）固定**、`gemini-3-pro-image` は **≒16:9（1408×768）固定**（指定に関わらず）。比率を厳守したいなら `--size` 直指定を試す or 別モデルで要検証。X 広告は 1:1 も 16:9 もどちらも有効なので致命傷ではない
-- **広告は背景だけでは不十分**: 生成した背景をそのまま渡すと「どこに何を配置するか」が空白で手直しが必要になる。コピー配置済みの原型（Figma 等のレイアウトモック）まで作って提示する。詳細は memory `project_x_ad_creative_exploration.md`
-- **`op whoami` の "not signed in"** は正常。署名状態を疑わない
-
-## 関連
-
-- メモリ: `project_x_ad_creative_exploration.md`（探索の全文脈・Round1結果）、`project_ui_tone.md`（トーン方針）
-- 後工程スキル: `compose-ad-creative`（背景＋コピー → カンプ PNG。文字乗せはこちら）
-- 既存スキル: `create-ad-shelf`（honn.me Twitter 広告 Shelf 作成。広告運用フローの姉妹）
+- **node 文脈ごとに未導入**: ai-cli は node のバージョンごとの global に入る。別バージョンに切り替わる repo 内で `ai` が `command not found` になったら、バージョンを固定して回避するのではなく `npm i -g ai-cli`（公式手順）で今の文脈に入れて再実行する。
+- **無料枠ブロック**: `Free tier users do not have access to this model` はモデルID誤りではなく**クレジット不足**。top-up が必要。
+- **Touch ID 連打**: 1 `op run` = 1 Touch ID。複数生成は `op run -- bash -c` で束ねる。
+- **aspect-ratio が効かない（モデル依存）**: ai-cli の `--aspect-ratio` は gemini で無視される。実測（2026-06-09）: `gemini-2.5-flash-image` は **1:1（1024×1024）固定**、`gemini-3-pro-image` は **≒16:9（1408×768）固定**（指定に関わらず）。比率を厳守したいなら `--size` 直指定を試す or 別モデルで要検証。
+- **`op whoami` の "not signed in"** は正常。署名状態を疑わない。


### PR DESCRIPTION
## 概要
`ai-image-gen` を**汎用の画像生成ツール**に純化する。このスキルは「Claude 本体が持たない画像生成機能を補う capability primitive」であって、広告クリエイティブ専用スキルではない。広告クリエイティブ固有の汚染（ブランドDNA・ビジュアル軸・姉妹スキル結合）を剥がし、どのプロダクト・どの用途でも使える状態に戻す。

## 背景
広告制作スキルスイートの設計を詰める中で、テイスト（クリエイティブの方向性）の管轄が整理された:

- **恒久ブランドDNA**（パレット・書体・トーン）→ 各プロダクトの `docs/product.md` が正本
- **都度のクリエイティブ方向** → `plan-ad-strategy`（戦略）が出す
- **画像生成そのもの** → この `ai-image-gen`（純粋な生成器）

役割がこう割れた結果、ai-image-gen が広告ワークフローやブランドDNAを抱える必要がなくなった。

## 変更点
- **「taberu.pro 広告クリエイティブ・ワークフロー」節を削除**（ブランドDNA・ビジュアル軸5方向・compose handoff）。この知見はメモリに既に資産化済みで、ブランドDNAは product.md 行き。
- **姉妹スキル結合を削除**（compose-ad-creative / create-ad-shelf）と設計思想の枕詞。汎用 Tips（「画像モデルは日本語が化けるので文字は別途乗せる」）だけ残す。
- **flash をデフォルトに**。上位モデル（pro / imagen / gpt-image）への変更は「品質問題がモデル起因と判明したときのエスカレーション」と位置づけ、先回りで高いモデルを使う運用をやめた。
- 出力パス例を汎用化（`out/`）、罠リストから広告固有の編集的注記を除去。

## 残したもの（capability の本体・無変更）
1Password/op run の秘匿鍵注入・nodenv 導入の罠・Touch ID 連打回避・主要フラグ・コスト/課金TODO・aspect-ratio のモデル依存挙動。

## 検証
ドキュメント（SKILL.md）のみのため自動テストなし。symlink は `Makefile` の `link-claude` ループが自動生成。広告/姉妹スキル結合ワードの残存を grep で確認済み（0件）。

## 関連
- `plan-ad-strategy`（#18・戦略でクリエイティブ方向を出す上流）
- `docs/product.md`（恒久ブランドDNAの正本・各プロダクト側で整備が必要）