### PR TITLE
chore(zsh): remove op-based ai() wrapper in favor of .env key resolution

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -139,8 +139,3 @@ if [ -f '/Users/tsujidaisuke/google-cloud-sdk/completion.zsh.inc' ]; then . '/Us
 
 # bun completions
 [ -s "/Users/tsujidaisuke/.bun/_bun" ] && source "/Users/tsujidaisuke/.bun/_bun"
-
-# vercel-labs/ai-cli: 1Password から実行時だけ API キーを注入する。
-ai() {
-  AI_GATEWAY_API_KEY="op://Private/AI Gateway/credential" op run -- ai "$@"
-}


### PR DESCRIPTION
## 概要

`.zshrc` から、1Password (`op run`) で実行時に API キーを注入していた `ai()` ラッパー関数を削除しました。

## 背景

`3f2a5e5` で ai-image-gen が `op` 依存をやめ、プロジェクトの `.env`（`AI_GATEWAY_API_KEY`）からキーを読む方式に移行しました。これにより vercel-labs/ai-cli 自身が `.env` からキーを解決するため、シェル側の `op run` ラッパーは不要になりました。

## 変更内容

- `.zshrc` の `ai()` 関数（`op run` で `AI_GATEWAY_API_KEY` を注入していたもの）を削除

## 影響

- `ai` コマンドは素の vercel-labs/ai-cli が走り、カレントディレクトリの `.env` からキーを読むようになります
- ai-image-gen スキルは元々プロジェクトの `.env` 前提なので整合済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 変更内容

* **チョア**
  * シェル設定から API キーの自動注入機構を削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->