### PR TITLE
feat(claude): warn on context window by absolute token count

### DIFF
--- a/claude/statusline-command.sh
+++ b/claude/statusline-command.sh
@@ -35,17 +35,24 @@ if [ -n "$model" ]; then
   line="$line $(printf "\033[35m%s\033[0m" "$model")"
 fi
 
-# context usage
-if [ -n "$used" ]; then
-  used_int=$(printf "%.0f" "$used")
-  if [ "$used_int" -ge 80 ]; then
-    color="\033[31m"
-  elif [ "$used_int" -ge 50 ]; then
-    color="\033[33m"
+# context usage（絶対トークン基準で警戒。1M/200k どちらのウィンドウでも
+# 作話バグの発火帯（OP報告: 100k〜170k）で確実に色が変わるよう実トークン数で判定する）
+tokens=$(echo "$input" | jq -r '.context_window.total_input_tokens // empty')
+if [ -n "$tokens" ]; then
+  k=$((tokens / 1000))
+  if [ "$tokens" -ge 100000 ]; then
+    color="\033[31m"   # 赤：作話発火帯（OP報告 100k〜）に到達、/clear 推奨
+  elif [ "$tokens" -ge 70000 ]; then
+    color="\033[33m"   # 黄：警戒、そろそろ畳む準備
   else
-    color="\033[36m"
+    color="\033[36m"   # シアン：安全
   fi
-  line="$line $(printf "${color}ctx:%s%%\033[0m" "$used_int")"
+  if [ -n "$used" ]; then
+    pct=$(printf "%.0f" "$used")
+    line="$line $(printf "${color}ctx:%sk(%s%%)\033[0m" "$k" "$pct")"
+  else
+    line="$line $(printf "${color}ctx:%sk\033[0m" "$k")"
+  fi
 fi
 
 printf "%b" "$line"


### PR DESCRIPTION
## 背景

statusline のコンテキスト使用量インジケータは `context_window.used_percentage`（%）で色分けしていた（50% で黄・80% で赤）。しかし `claude-opus-4-8[1m]`（1M コンテキストウィンドウ）では、長コンテキスト時に出力が不安定になりやすい帯（約 100k〜170k トークン。参照: anthropics/claude-code#67606）が **わずか 10〜17%** にしか表示されず、従来の 50%/80% 閾値が一度も発火しなかった。ウィンドウを広げたことで、警告センサーの感度が実質的に無効化されていた。

## 変更内容

色分けの基準を %（相対）から `context_window.total_input_tokens`（絶対トークン数）に変更した。これにより 1M でも 200k でも同じトークン量で発火する。

- 🟡 黄: 70k 以上（警戒）
- 🔴 赤: 100k 以上（リスク帯の入口）
- それ未満: シアン（安全）
- 表示は `ctx:110k(11%)` のように絶対値と % を併記。`used_percentage` が無い場合（`/compact` 直後など）は `ctx:110k` と k のみ表示にフォールバック。

## 検証

サンプル JSON を流してローカル確認済み:

- 110k → 赤
- 80k → 黄
- 50k → シアン
- `used_percentage` 欠損時 → `ctx:110k`（k のみ）
- `context_window` 自体が無い場合 → 例外なく無表示

## 補足

閾値（70k / 100k）は issue #67606 の報告帯と、本作業セッションで約 110k トークン時点に実際に出力の不整合が再現したことを根拠にした初期値。運用しながら調整可能。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ステータスラインのコンテキスト使用量表示を、%ベースからトークン数ベースに変更しました。
  * `ctx:12k` のように、1000トークン単位でより分かりやすく表示されます。
  * 使用率が取得できる場合は `ctx:12k(84%)` のように併記されます。
  * 表示色のしきい値も新しいトークン数基準に更新されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->