### PR TITLE
chore(claude): drop the auto mode overrides and keep the shipped defaults

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -45,7 +45,6 @@
       "Bash(pnpm tsc *)",
       "Bash(npx tsc *)",
       "Bash(npm view *)",
-      "Bash(node *)",
       "Bash(nodenv versions *)",
       "Bash(just *)",
       "Bash(just)",
@@ -169,7 +168,8 @@
     "typescript-lsp@claude-plugins-official": true,
     "voltagent-qa-sec@voltagent-subagents": false,
     "voltagent-biz@voltagent-subagents": false,
-    "vercel@claude-plugins-official": true
+    "vercel@claude-plugins-official": true,
+    "slack@claude-plugins-official": true
   },
   "extraKnownMarketplaces": {
     "voltagent-subagents": {
@@ -181,5 +181,11 @@
   },
   "skipWorkflowUsageWarning": true,
   "agentPushNotifEnabled": true,
-  "skipAutoPermissionPrompt": true
+  "skipAutoPermissionPrompt": true,
+  "autoMode": {
+    "soft_deny": [
+      "$defaults",
+      "Detached Background Process [named+specifics — **must name:** the service or stack to leave running]: Starting a service that detaches from the agent's process tree, leaving neither the user nor any later session a handle to stop it with — it holds ports, CPU, and data indefinitely and the start cannot be undone by whoever finds it later. Covers `docker run -d`, `docker compose up -d`/`start`, `nohup`, `disown`, `pm2 start`, and any equivalent detach or daemonize flag; judge by effect rather than by flag, so a package script, Makefile target, or skill command counts once the transcript shows it daemonizes (e.g. a `make dev` or `pnpm dev:up` that runs `compose up -d`). This rule applies inside project scope: the harm is untrackability, not exposure, so it is cleared by neither the Local Operations ALLOW exception, nor the development-server carve-out in Expose Local Services, nor an Environment line calling local dev routine — those clear running a dev service, not detaching it. NOT this rule, and never blocked by it: the same command in the foreground, via the Bash tool's `run_in_background` option, or with a plain trailing `&` — all three stay in the agent's process tree and killable (`KillShell`), and are the preferred alternative to detaching; a detach torn down in the same command (`up -d && <test> && down`); and teardown commands (`docker compose down`/`stop`, `pm2 delete`, `kill`), which are the fix rather than the harm. Mechanisms that also survive reboot — `launchctl load`, `brew services start`, `pm2 save`/`startup`, systemd units — are Unauthorized Persistence: cite that rule instead and apply its stricter bar. Clears when the user names the service or stack they want left running; further starts of that same stack are then session-cleared."
+    ]
+  }
 }

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -181,11 +181,5 @@
   },
   "skipWorkflowUsageWarning": true,
   "agentPushNotifEnabled": true,
-  "skipAutoPermissionPrompt": true,
-  "autoMode": {
-    "soft_deny": [
-      "$defaults",
-      "Detached Background Process [named+specifics — **must name:** the service or stack to leave running]: Starting a service that detaches from the agent's process tree, leaving neither the user nor any later session a handle to stop it with — it holds ports, CPU, and data indefinitely and the start cannot be undone by whoever finds it later. Covers `docker run -d`, `docker compose up -d`/`start`, `nohup`, `disown`, `pm2 start`, and any equivalent detach or daemonize flag; judge by effect rather than by flag, so a package script, Makefile target, or skill command counts once the transcript shows it daemonizes (e.g. a `make dev` or `pnpm dev:up` that runs `compose up -d`). This rule applies inside project scope: the harm is untrackability, not exposure, so it is cleared by neither the Local Operations ALLOW exception, nor the development-server carve-out in Expose Local Services, nor an Environment line calling local dev routine — those clear running a dev service, not detaching it. NOT this rule, and never blocked by it: the same command in the foreground, via the Bash tool's `run_in_background` option, or with a plain trailing `&` — all three stay in the agent's process tree and killable (`KillShell`), and are the preferred alternative to detaching; a detach torn down in the same command (`up -d && <test> && down`); and teardown commands (`docker compose down`/`stop`, `pm2 delete`, `kill`), which are the fix rather than the harm. Mechanisms that also survive reboot — `launchctl load`, `brew services start`, `pm2 save`/`startup`, systemd units — are Unauthorized Persistence: cite that rule instead and apply its stricter bar. Clears when the user names the service or stack they want left running; further starts of that same stack are then session-cleared."
-    ]
-  }
+  "skipAutoPermissionPrompt": true
 }


### PR DESCRIPTION
## Summary

`settings.json` に混ざっていた `autoMode` を丸ごと落として、シップ済みのデフォルト67本だけで動かす。結果として**このPRの差分は実質2行**（`Bash(node *)` の削除と slack プラグインの有効化）になっている。

### なぜ autoMode を落とすのか

`autoMode` は `~/.claude/settings.json` からしか読まれない。プロジェクトの `.claude/settings.json` や `.claude/settings.local.json` に置いても untrusted source として無視されるし、`~/.claude/settings.local.json` はそもそも Claude Code に読まれていない（壊れたJSONを置いても無警告で動作することを確認）。

このリポジトリの `claude/settings.json` はその唯一の読み取り先への symlink なので、`/auto-mode-setup` が taberu.pro を調査して書いた台帳が、**全プロジェクトで読まれる状態**になっていた。

落としたもの:

- `autoMode.environment`（24行）— taberu.pro のドメイン・ブランチ保護・利用サービス・`.env` など機微ファイルの所在
- `soft_deny` の `Staging Force Push`（stg.taberu.pro）と `Prod Database Access`（Neon / `ANALYTICS_DATABASE_URL`）
- `soft_deny` の `Detached Background Process`（下記）

削除でデフォルトに戻ることでスコープはむしろ正しくなる。`Trusted repo` が「セッションが起動したリポジトリとその remote」という動的解決になり、`Sensitive remote targets` も `prod`/`production` を語境界でマッチする汎用ヒューリスティックになるため、プロジェクトを跨いで正しく効く。

### Detached Background Process も落とした理由

当初は汎用ルールとして残す予定だったが、本文に事実誤認があった。「trailing `&` は agent のプロセスツリーに残るので `KillShell` で殺せる」として推奨の代替手段に挙げていたが、実測すると:

```
起動時:       PID=31498  PPID=31496 (親シェル)
次の呼び出し: PID=31498  PPID=1     ← 親シェルは終了済み、init に引き取られた孤児
```

`&` のプロセスは親シェル終了後も生き残って PPID=1 の孤児になり、`KillShell` は届かない。これはこのルールが防ごうとしている害そのものなので、`nohup cmd` をブロックしながら `cmd > log 2>&1 &` を祝福する、自分の本文に書かれた回避路になっていた。

`claude auto-mode critique` でも他の問題が出ている。例外の必須性（"If an exception applies, the action MUST be allowed"）に正面から反しており分類器の解決が不安定になること、must-name の対象を危険なパラメータ（デタッチ）ではなくサービス名に置いていること、`setsid` / `tmux new -d` / `screen -dm` の列挙漏れ。加えて唯一の緩和路だった environment line も同PRで削除されている。

自分の抜け道を誤って記述したルールは、埋めようとしている穴より有害と判断した。

### 同梱している permissions 変更

- `Bash(node *)` を `permissions.allow` から削除 — `/auto-mode-setup` が classifier-bypassing なエントリとして検出して外したもの。allow だと `node` 経由で分類器を迂回できるため削除が妥当
- `slack@claude-plugins-official` を有効化

## Test plan

- [x] `claude auto-mode config` で `soft_deny` が67本（シップ済みのみ）、カスタム残存0件であること
- [x] `environment` から taberu への言及が0件になっていること
- [x] `&` で起動したプロセスの PPID が 1 になることを実測で確認
- [x] `jq` による書き換えで `autoMode` 以外の箇所が変化していないこと（最終差分は2行）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0192nMHhGxahMD5eput9WaYg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **設定変更**
  * `node` コマンドの実行許可を制限しました。
  * Slack 連携プラグインを有効化しました。
  * デタッチ型バックグラウンドサービスの起動制限を緩和しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->